### PR TITLE
Updates to remove deprecation warnings

### DIFF
--- a/app/src/androidTest/java/com/banno/android/gordontest/FailingTest.kt
+++ b/app/src/androidTest/java/com/banno/android/gordontest/FailingTest.kt
@@ -1,6 +1,6 @@
 package com.banno.android.gordontest
 
-import junit.framework.Assert.fail
+import org.junit.Assert.fail
 import org.junit.Test
 
 class FailingTest {


### PR DESCRIPTION
Get APK file providers from the `package` task instead of from "outputs" on the variant, which is deprecated