### PR TITLE
Fix xmlpull unsupported feature

### DIFF
--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/Xml.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/Xml.kt
@@ -7,12 +7,24 @@ import java.io.StringWriter
 internal fun xmlDocument(block: XmlSerializer.() -> Unit) = StringWriter().also {
     XmlPullParserFactory.newInstance(System.getProperty(XmlPullParserFactory.PROPERTY_NAME), null).newSerializer().run {
         setOutput(it)
-        setFeature("http://xmlpull.org/v1/doc/features.html#indent-output", true)
+        indentOutput()
         startDocument("UTF-8", null)
         block()
         endDocument()
     }
 }.toString()
+
+private fun XmlSerializer.indentOutput() {
+    try {
+        setFeature("http://xmlpull.org/v1/doc/features.html#indent-output", true)
+    } catch (ignored: Throwable) {
+        try {
+            setProperty("http://xmlpull.org/v1/doc/properties.html#serializer-indentation", "  ")
+            setProperty("http://xmlpull.org/v1/doc/properties.html#serializer-line-separator", "\n")
+        } catch (ignored: Throwable) {
+        }
+    }
+}
 
 internal fun XmlSerializer.attribute(name: String, value: String) {
     attribute("", name, value)


### PR DESCRIPTION
Fixes #6

Apparently different implementations of xmlpull support different ways of pretty-printing. This should fix unsupported feature exceptions by trying one way, and if that throws an exception trying the other way, and if that throws an exception it gets caught and the xml just won't be pretty.
