### PR TITLE
Install APKs Sequentially

### DIFF
--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonTestTask.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonTestTask.kt
@@ -85,7 +85,6 @@ internal abstract class GordonTestTask : DefaultTask() {
             }
 
             pools.flatMap { it.devices }.reinstall(
-                dispatcher = Dispatchers.Default,
                 logger = logger,
                 applicationPackage = applicationPackage,
                 instrumentationPackage = instrumentationPackage,


### PR DESCRIPTION
Installing APKs in parallel is faster but prone to timing out depending on the number of devices attached to ADB. This installs sequentially to avoid that issue.

This also gives a better error message when an APK times out on the install.