### PR TITLE
Add testInstrumentationRunner option to extension

### DIFF
--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonExtension.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonExtension.kt
@@ -13,11 +13,13 @@ abstract class GordonExtension @Inject constructor(
     val retryQuota: Property<Int> = objects.property()
     val testTimeoutMillis: Property<Long> = objects.property()
     val testFilter: Property<String> = objects.property()
+    val testInstrumentationRunner: Property<String> = objects.property()
 
     init {
         poolingStrategy.convention(PoolingStrategy.EachDevice)
         retryQuota.convention(0)
         testTimeoutMillis.convention(120_000)
         testFilter.convention("")
+        testInstrumentationRunner.convention("")
     }
 }

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonPlugin.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonPlugin.kt
@@ -40,7 +40,7 @@ class GordonPlugin : Plugin<Project> {
 
                 val instrumentationRunnerOptions = InstrumentationRunnerOptions(
                     testInstrumentationRunner = testedVariant.mergedFlavor.testInstrumentationRunner
-                        ?: throw NoTestInstrumentationRunnerException,
+                        ?: "android.test.InstrumentationTestRunner",
                     testInstrumentationRunnerArguments = testedVariant.mergedFlavor.testInstrumentationRunnerArguments,
                     animationsDisabled = androidExtension.testOptions.animationsDisabled
                 )
@@ -49,7 +49,7 @@ class GordonPlugin : Plugin<Project> {
 
                 this.instrumentationApk.apply { set(project.layout.file(instrumentationApk)) }.finalizeValue()
                 this.applicationApk.apply { set(project.layout.file(applicationApk)) }.finalizeValue()
-                this.instrumentationRunnerOptions.apply { set(instrumentationRunnerOptions) }.finalizeValue()
+                this.androidInstrumentationRunnerOptions.apply { set(instrumentationRunnerOptions) }.finalizeValue()
             }
         }
     }
@@ -63,8 +63,4 @@ class GordonPlugin : Plugin<Project> {
 
         File(packageAppTask.outputDirectory, apkName)
     }
-
-    object NoTestInstrumentationRunnerException : IllegalStateException(
-        "Gordon cannot be used without a testInstrumentationRunner, such as `androidx.test.runner.AndroidJUnitRunner`"
-    )
 }


### PR DESCRIPTION
Allow overriding `testInstrumentationRunner` in the `gordon` extension. This is highly unlikely to be needed for most use cases, so I didn't bother adding it to the README.