### PR TITLE
Support `Suppress`, `SdkSuppress`, and `RequiresDevice` annotations

### DIFF
--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/TestRunner.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/TestRunner.kt
@@ -54,6 +54,11 @@ internal fun runTest(
                     TestResult.Passed(testTime)
                 }
 
+                shellOutput.endsWith("OK (0 tests)") -> {
+                    logger.lifecycle("${device.serial}: $testName: IGNORED")
+                    TestResult.Ignored
+                }
+
                 else -> {
                     val failureOutput = shellOutput.substringBeforeLast("There was 1 failure")
                     logger.error("${device.serial}: $testName: FAILED\n$failureOutput\n")


### PR DESCRIPTION
Closes #25

The Android `Suppress`, `SdkSuppress`, and `RequiresDevice` annotations result in output ending with `OK (0 tests)` instead of `OK (1 test)`, so we just mark the test as ignored instead of failed in that case.