### PR TITLE
Add support for parameterized runner at method level

### DIFF
--- a/app/src/androidTest/java/com/banno/android/gordontest/ParameterizedTest.kt
+++ b/app/src/androidTest/java/com/banno/android/gordontest/ParameterizedTest.kt
@@ -1,0 +1,31 @@
+package com.banno.android.gordontest
+
+import org.junit.Assert
+import org.junit.Assume
+import org.junit.Ignore
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+
+@RunWith(Parameterized::class)
+class ParameterizedTest(private val parameter: Any) {
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun parameters(): Iterable<Array<Any>> {
+            return listOf(
+                arrayOf(1 as Any),
+                arrayOf("arg" as Any)
+            )
+        }
+    }
+
+    @Test fun parameterizedA() = Assert.assertEquals(1, 1)
+    @Test fun parameterizedB() = Assume.assumeTrue(1 == parameter)
+    @Test fun parameterizedC() = Assert.assertTrue(1 == parameter)
+
+    @Ignore
+    @Test
+    fun parameterizedD() = Assert.assertEquals(1, 1)
+}

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/TestRunner.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/TestRunner.kt
@@ -48,7 +48,7 @@ internal fun runTest(
                     TestResult.Failed(testTime, "Test timed out", device.serial)
                 }
 
-                shellOutput.endsWith("OK (1 test)") -> {
+                shellOutput.matches(Regex(".*OK \\([1-9][0-9]* tests?\\)$", RegexOption.DOT_MATCHES_ALL)) -> {
                     logger.lifecycle("$progress -> ${device.serial}: ${test.classAndMethodName}: PASSED")
                     TestResult.Passed(testTime)
                 }

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/TestSuiteLoader.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/TestSuiteLoader.kt
@@ -44,7 +44,7 @@ private val BasicAnnotation.name
     get() = type.drop(1).dropLast(1).replace('/', '.')
 
 private val Annotatable.annotationNames
-    get() = annotations.map { it.name }.toSet() - "kotlin.Metadata"
+    get() = annotations.map { it.name }.toSet() - "kotlin.Metadata" - "dalvik.annotation.MemberClasses"
 
 private val Annotatable.isIgnored
     get() = annotationNames.any { it == "org.junit.Ignore" }

--- a/gordon-plugin/src/test/kotlin/com/banno/gordon/TestSuiteLoaderTest.kt
+++ b/gordon-plugin/src/test/kotlin/com/banno/gordon/TestSuiteLoaderTest.kt
@@ -39,6 +39,10 @@ class TestSuiteLoaderTest {
             TestCase("com.banno.android.gordontest.InheritedTest", "interfaceA", false, setOf("org.junit.Test")),
             TestCase("com.banno.android.gordontest.InheritedTest", "interfaceB", false, setOf("org.junit.Test")),
             TestCase("com.banno.android.gordontest.InheritedTest", "interfaceC", false, setOf("org.junit.Test")),
+            TestCase("com.banno.android.gordontest.ParameterizedTest", "parameterizedA", false, setOf("org.junit.runner.RunWith", "org.junit.Test")),
+            TestCase("com.banno.android.gordontest.ParameterizedTest", "parameterizedB", false, setOf("org.junit.runner.RunWith", "org.junit.Test")),
+            TestCase("com.banno.android.gordontest.ParameterizedTest", "parameterizedC", false, setOf("org.junit.runner.RunWith", "org.junit.Test")),
+            TestCase("com.banno.android.gordontest.ParameterizedTest", "parameterizedD", true, setOf("org.junit.runner.RunWith", "org.junit.Ignore", "org.junit.Test")),
             TestCase("com.banno.android.gordontest.StandardTest", "standardA", false, setOf("org.junit.Test")),
             TestCase("com.banno.android.gordontest.StandardTest", "standardB", false, setOf("org.junit.Test")),
             TestCase("com.banno.android.gordontest.StandardTest", "standardC", true, setOf("org.junit.Ignore", "org.junit.Test"))


### PR DESCRIPTION
The JUnit Parameterized runner allows to run many times a test methods with different parameters. From the Android command line tool, `am instrumentation`, without the output in raw format (using `-r` option), this is the same than a normal test method, but the outcome test results are understood as:
- ignored when all are ignored
- failure when one is failing
- success when all are successful or some are ignored (*)

In case of success, the string "OK (XX tests)" is printed instead of "OK (1 test)".

Note that to have a finer granularity and fully handle the case (*), then the raw format should be supported first.

This should solve the issue #46.