### PR TITLE
Initial work toward supporting configuration caching

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -151,6 +151,9 @@
       <option name="ALIGN_MULTILINE_PARAMETERS_IN_CALLS" value="true" />
       <option name="METHOD_ANNOTATION_WRAP" value="5" />
       <option name="FIELD_ANNOTATION_WRAP" value="5" />
+      <indentOptions>
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+      </indentOptions>
     </codeStyleSettings>
   </code_scheme>
 </component>

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonPlugin.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonPlugin.kt
@@ -76,6 +76,10 @@ class GordonPlugin : Plugin<Project> {
                     )
                 }.finalizeValue()
 
+                if (androidPluginType == AndroidPluginType.DYNAMIC_FEATURE) {
+                    this.dynamicFeatureModuleName.apply { set(project.name) }.finalizeValue()
+                }
+
                 this.instrumentationApk.apply { set(testVariant.apkOutputFile()) }.finalizeValue()
                 this.instrumentationPackage.apply { set(testVariant.applicationId) }.finalizeValue()
                 this.androidInstrumentationRunnerOptions.apply { set(instrumentationRunnerOptions) }.finalizeValue()

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonPlugin.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonPlugin.kt
@@ -21,7 +21,7 @@ class GordonPlugin : Plugin<Project> {
         val androidPluginType = project.androidPluginType()
             ?: error("Gordon plugin must be applied after applying the application, library, or dynamic-feature Android plugin")
 
-        project.extensions.create<GordonExtension>("gordon")
+        val gordonExtension = project.extensions.create<GordonExtension>("gordon")
 
         val androidExtension = project.extensions.getByType<TestedExtension>()
 
@@ -82,6 +82,16 @@ class GordonPlugin : Plugin<Project> {
 
                 this.instrumentationApk.apply { set(testVariant.apkOutputFile()) }.finalizeValue()
                 this.instrumentationPackage.apply { set(testVariant.applicationId) }.finalizeValue()
+
+                this.poolingStrategy.apply { set(gordonExtension.poolingStrategy) }.finalizeValue()
+                this.tabletShortestWidthDp.apply { set(gordonExtension.tabletShortestWidthDp) }.finalizeValue()
+                this.retryQuota.apply { set(gordonExtension.retryQuota) }.finalizeValue()
+                this.installTimeoutMillis.apply { set(gordonExtension.installTimeoutMillis) }.finalizeValue()
+                this.testTimeoutMillis.apply { set(gordonExtension.testTimeoutMillis) }.finalizeValue()
+                this.extensionTestFilter.apply { set(gordonExtension.testFilter) }.finalizeValue()
+                this.extensionTestInstrumentationRunner.apply { set(gordonExtension.testInstrumentationRunner) }
+                    .finalizeValue()
+
                 this.androidInstrumentationRunnerOptions.apply { set(instrumentationRunnerOptions) }.finalizeValue()
             }
         }

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonTestTask.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonTestTask.kt
@@ -19,7 +19,6 @@ import org.gradle.api.tasks.PathSensitive
 import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
-import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.property
 import se.vidstige.jadb.JadbConnection
 import java.io.File
@@ -73,24 +72,22 @@ internal abstract class GordonTestTask @Inject constructor(
             .map { it.replace('#', '.') }
 
     @get:Input
-    internal val poolingStrategy = project.extensions.getByType<GordonExtension>().poolingStrategy
+    internal val poolingStrategy: Property<PoolingStrategy> = objects.property()
 
     @get:Input
-    internal val tabletShortestWidthDp = project.extensions.getByType<GordonExtension>().tabletShortestWidthDp
+    internal val tabletShortestWidthDp: Property<Int> = objects.property()
 
-    private val retryQuota = project.extensions.getByType<GordonExtension>().retryQuota
-    private val installTimeoutMillis = project.extensions.getByType<GordonExtension>().installTimeoutMillis
-    private val testTimeoutMillis = project.extensions.getByType<GordonExtension>().testTimeoutMillis
+    internal val retryQuota: Property<Int> = objects.property()
+    internal val installTimeoutMillis: Property<Long> = objects.property()
+    internal val testTimeoutMillis: Property<Long> = objects.property()
+
+    internal val extensionTestFilter: Property<String> = objects.property()
+    internal val extensionTestInstrumentationRunner: Property<String> = objects.property()
 
     @Option(option = "tests", description = "Comma-separated packages, classes, methods, or annotations.")
     val commandlineTestFilter: Property<String> = objects.property()
 
-    private val extensionTestFilter = project.extensions.getByType<GordonExtension>().testFilter
-
     internal val androidInstrumentationRunnerOptions: Property<InstrumentationRunnerOptions> = objects.property()
-
-    private val extensionTestInstrumentationRunner =
-        project.extensions.getByType<GordonExtension>().testInstrumentationRunner
 
     @OutputDirectory
     val testResultsDirectory: Provider<Directory> = projectLayout.buildDirectory.dir("test-results/$name")

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonTestTask.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonTestTask.kt
@@ -47,6 +47,9 @@ internal abstract class GordonTestTask @Inject constructor(
     internal val signingConfigCredentials: Property<SigningConfigCredentials> = objects.property()
 
     @get:Input
+    internal val dynamicFeatureModuleName: Property<String> = objects.property()
+
+    @get:Input
     internal val applicationPackage: Property<String> = objects.property()
 
     @get:Input
@@ -98,6 +101,7 @@ internal abstract class GordonTestTask @Inject constructor(
     init {
         applicationAab.convention { PLACEHOLDER_APPLICATION_AAB }
         signingKeystoreFile.convention { PLACEHOLDER_SIGNING_KEYSTORE }
+        dynamicFeatureModuleName.convention(PLACEHOLDER_DYNAMIC_MODULE_NAME)
         applicationPackage.convention(PLACEHOLDER_APPLICATION_PACKAGE)
         commandlineTestFilter.convention("")
     }
@@ -127,6 +131,7 @@ internal abstract class GordonTestTask @Inject constructor(
 
             val applicationAab = applicationAab.get().asFile.takeUnless { it == PLACEHOLDER_APPLICATION_AAB }
             val applicationPackage = applicationPackage.get().takeUnless { it == PLACEHOLDER_APPLICATION_PACKAGE }
+            val dynamicModuleName = dynamicFeatureModuleName.get().takeUnless { it == PLACEHOLDER_DYNAMIC_MODULE_NAME }
 
             val signingConfig = SigningConfig(
                 storeFile = signingKeystoreFile.get().asFile.takeUnless { it == PLACEHOLDER_SIGNING_KEYSTORE },
@@ -140,7 +145,7 @@ internal abstract class GordonTestTask @Inject constructor(
                 logger = logger,
                 applicationPackage = applicationPackage,
                 instrumentationPackage = instrumentationPackage.get(),
-                dynamicModule = project.name.takeIf { project.androidPluginType() == AndroidPluginType.DYNAMIC_FEATURE },
+                dynamicModule = dynamicModuleName,
                 applicationAab = applicationAab,
                 signingConfig = signingConfig,
                 instrumentationApk = instrumentationApk.get().asFile,
@@ -202,4 +207,5 @@ internal fun TestCase.matchesFilter(filters: List<String>): Boolean {
 
 private val PLACEHOLDER_APPLICATION_AAB = File.createTempFile("PLACEHOLDER_APPLICATION_AAB", null)
 private val PLACEHOLDER_SIGNING_KEYSTORE = File.createTempFile("PLACEHOLDER_SIGNING_KEYSTORE", null)
+private const val PLACEHOLDER_DYNAMIC_MODULE_NAME = "PLACEHOLDER_DYNAMIC_MODULE_NAME"
 private const val PLACEHOLDER_APPLICATION_PACKAGE = "PLACEHOLDER_APPLICATION_PACKAGE"

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonTestTask.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonTestTask.kt
@@ -5,6 +5,7 @@ import arrow.fx.extensions.fx
 import kotlinx.coroutines.Dispatchers
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.Directory
+import org.gradle.api.file.ProjectLayout
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.model.ObjectFactory
@@ -26,7 +27,8 @@ import javax.inject.Inject
 
 @CacheableTask
 internal abstract class GordonTestTask @Inject constructor(
-    objects: ObjectFactory
+    objects: ObjectFactory,
+    projectLayout: ProjectLayout
 ) : DefaultTask() {
 
     @get:InputFile
@@ -88,10 +90,10 @@ internal abstract class GordonTestTask @Inject constructor(
         project.extensions.getByType<GordonExtension>().testInstrumentationRunner
 
     @OutputDirectory
-    val testResultsDirectory: Provider<Directory> = project.layout.buildDirectory.dir("test-results/$name")
+    val testResultsDirectory: Provider<Directory> = projectLayout.buildDirectory.dir("test-results/$name")
 
     @OutputDirectory
-    val reportDirectory: Provider<Directory> = project.layout.buildDirectory.dir("reports/$name")
+    val reportDirectory: Provider<Directory> = projectLayout.buildDirectory.dir("reports/$name")
 
     init {
         applicationAab.convention { PLACEHOLDER_APPLICATION_AAB }

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonTestTask.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonTestTask.kt
@@ -7,6 +7,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.file.Directory
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.logging.LogLevel
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
@@ -21,30 +22,33 @@ import org.gradle.kotlin.dsl.getByType
 import org.gradle.kotlin.dsl.property
 import se.vidstige.jadb.JadbConnection
 import java.io.File
+import javax.inject.Inject
 
 @CacheableTask
-internal abstract class GordonTestTask : DefaultTask() {
+internal abstract class GordonTestTask @Inject constructor(
+    objects: ObjectFactory
+) : DefaultTask() {
 
     @get:InputFile
     @get:PathSensitive(PathSensitivity.NAME_ONLY)
-    internal val instrumentationApk: RegularFileProperty = project.objects.fileProperty()
+    internal val instrumentationApk: RegularFileProperty = objects.fileProperty()
 
     @get:InputFile
     @get:PathSensitive(PathSensitivity.NAME_ONLY)
-    internal val applicationAab: RegularFileProperty = project.objects.fileProperty()
+    internal val applicationAab: RegularFileProperty = objects.fileProperty()
 
     @get:InputFile
     @get:PathSensitive(PathSensitivity.NAME_ONLY)
-    internal val signingKeystoreFile: RegularFileProperty = project.objects.fileProperty()
+    internal val signingKeystoreFile: RegularFileProperty = objects.fileProperty()
 
     @get:Input
-    internal val signingConfigCredentials: Property<SigningConfigCredentials> = project.objects.property()
+    internal val signingConfigCredentials: Property<SigningConfigCredentials> = objects.property()
 
     @get:Input
-    internal val applicationPackage: Property<String> = project.objects.property()
+    internal val applicationPackage: Property<String> = objects.property()
 
     @get:Input
-    internal val instrumentationPackage: Property<String> = project.objects.property()
+    internal val instrumentationPackage: Property<String> = objects.property()
 
     @get:Input
     internal val instrumentationRunnerOptions: InstrumentationRunnerOptions
@@ -74,12 +78,11 @@ internal abstract class GordonTestTask : DefaultTask() {
     private val testTimeoutMillis = project.extensions.getByType<GordonExtension>().testTimeoutMillis
 
     @Option(option = "tests", description = "Comma-separated packages, classes, methods, or annotations.")
-    val commandlineTestFilter: Property<String> = project.objects.property()
+    val commandlineTestFilter: Property<String> = objects.property()
 
     private val extensionTestFilter = project.extensions.getByType<GordonExtension>().testFilter
 
-    internal val androidInstrumentationRunnerOptions: Property<InstrumentationRunnerOptions> =
-        project.objects.property()
+    internal val androidInstrumentationRunnerOptions: Property<InstrumentationRunnerOptions> = objects.property()
 
     private val extensionTestInstrumentationRunner =
         project.extensions.getByType<GordonExtension>().testInstrumentationRunner


### PR DESCRIPTION
Related to #50

To support Gradle configuration caching, the task can no longer use the `project` object directly. This was fairly simple to resolve by using injected `ObjectFactory` and `ProjectLayout` objects, and using properties that the plugin takes care of setting instead of the task itself.