### PR TITLE
Github Action for publishing releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,35 @@
+name: Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish Plugin
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+
+    - uses: actions/checkout@v2
+
+    - uses: actions/cache@v1
+      with:
+        path: ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle*.properties') }}
+
+    - uses: actions/cache@v1
+      with:
+        path: ~/.gradle/caches
+        key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/*.gradle*') }}-${{ hashFiles('**/gradle*.properties') }}
+
+    - name: Gradle Publish
+      env:
+        GRADLE_PLUGIN_PUBLISH_KEY: ${{ secrets.GRADLE_PLUGIN_PUBLISH_KEY }}
+        GRADLE_PLUGIN_PUBLISH_SECRET: ${{ secrets.GRADLE_PLUGIN_PUBLISH_SECRET }}
+      run: |
+        ./gradlew publishPlugins

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,67 @@
+name: Draft Release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  release:
+    name: Draft Release
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - id: get_previous_release
+      uses: thebritican/fetch-latest-release@v2.0.0
+
+    - id: get_new_version
+      uses: christian-draeger/read-properties@1.0.1
+      with:
+        path: 'gordon-plugin/gradle.properties'
+        property: 'version'
+
+    - run: |
+        PREVIOUS_TAG=${{ steps.get_previous_release.outputs.tag_name }}
+        echo "::set-env name=previousTag::$PREVIOUS_TAG"
+        NEW_TAG=${{ steps.get_new_version.outputs.value }}
+        echo "::set-env name=newTag::$NEW_TAG"
+
+    - name: Create Tag
+      run: |
+        git tag -a ${{ env.newTag }} -m ${{ env.newTag }}
+        git push origin ${{ env.newTag }}
+
+    - name: Generate Changelog
+      id: generate_changelog
+      uses: nblagoev/pull-release-notes-action@v1
+      with:
+        base-ref: ${{ env.previousTag }}
+        head-ref: ${{ env.newTag }}
+
+    - name: Draft Release
+      uses: actions/create-release@v1
+      with:
+        tag_name: ${{ env.newTag }}
+        release_name: ${{ env.newTag }}
+        body: ${{steps.generate_changelog.outputs.result}}
+        draft: true
+
+    - id: next_version
+      uses: jessicalostinspace/bump-semantic-version-action@v1.0.1
+      with:
+        semantic-version: ${{ env.newTag }}
+        version-type: 'PATCH'
+
+    - name: Bump Version
+      uses: christian-draeger/write-properties@1.0.1
+      with:
+        path: 'gordon-plugin/gradle.properties'
+        property: 'version'
+        value: ${{steps.next_version.outputs.bumped-semantic-version}}
+
+    - name: Commit Version Bump
+      run: |
+        git add gordon-plugin/gradle.properties
+        git commit -m "Automatic patch version bump"
+        git push

--- a/jenkins-jobs/deploy/Jenkinsfile
+++ b/jenkins-jobs/deploy/Jenkinsfile
@@ -1,2 +1,0 @@
-library('android-shared')
-publishProjectAndIncrementVersion(':gordon-plugin:assemble', 'publishPlugins', 'gordon-plugin/gradle.properties', true, true)


### PR DESCRIPTION
Use Github Actions for publishing releases, removing the dependency on Banno shared Jenkins stuff
- To do a release, we'll manually trigger the `Draft Release` workflow, which will create a tag and a draft release, and then bump the patch version in master to prepare for the next release
- Then we'll do any desired editing of the draft release notes, publish it, and then the `Publish` workflow will automatically run the Gradle publish