### PR TITLE
Update to Android Gradle Plugin 4.1

### DIFF
--- a/gordon-plugin/build.gradle.kts
+++ b/gordon-plugin/build.gradle.kts
@@ -13,13 +13,15 @@ repositories {
     maven("https://www.jitpack.io")
 }
 
+val androidGradlePluginVersion: String by project
+val aapt2Version: String by project
+
 dependencies {
     implementation(gradleKotlinDsl())
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.9")
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-runtime:0.20.0")
     implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.2")
 
-    val androidGradlePluginVersion: String by project
     implementation("com.android.tools.build:gradle:$androidGradlePluginVersion")
     implementation("com.android.tools.build:bundletool:1.2.0")
     implementation("org.smali:dexlib2:2.4.0")
@@ -37,7 +39,6 @@ tasks.withType<Test>().configureEach {
     testLogging.exceptionFormat = org.gradle.api.tasks.testing.logging.TestExceptionFormat.FULL
 }
 
-val aapt2Version = "4.0.1-6197926"
 val jar = tasks.named<Jar>("jar")
 mapOf(
     "linux" to "linux/",

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
-androidGradlePluginVersion=4.0.1
+androidGradlePluginVersion=4.1.0
+aapt2Version=4.1.0-6503028
 kotlinVersion=1.4.10
 kotlinterVersion=3.2.0
 gradlePluginPublishVersion=0.12.0


### PR DESCRIPTION
- Update to AGP 4.1.0
- Refactor `GordonPlugin` to work with the newly available AGP interfaces. The diff is hard to parse, but there's actually hardly anything changed. The main thing is that we're now using `artifacts.get` instead of manually finding output files and depending on literal task names. The exception is dynamic feature modules - AGP doesn't seem have nice new interfaces for that yet, so we're still stuck with the old logic for that case.

Closes #41
