### PR TITLE
Update release action to new syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,9 +25,9 @@ jobs:
 
     - run: |
         PREVIOUS_TAG=${{ steps.get_previous_release.outputs.tag_name }}
-        echo "::set-env name=previousTag::$PREVIOUS_TAG"
+        echo "previousTag=$PREVIOUS_TAG" >> $GITHUB_ENV
         NEW_TAG=${{ steps.get_new_version.outputs.value }}
-        echo "::set-env name=newTag::$NEW_TAG"
+        echo "newTag=$NEW_TAG" >> $GITHUB_ENV
 
     - name: Create Tag
       uses: simpleactions/create-tag@v1.0.0


### PR DESCRIPTION
See https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands