### PR TITLE
Fix support for install-time dynamic modules

### DIFF
--- a/gordon-plugin/build.gradle.kts
+++ b/gordon-plugin/build.gradle.kts
@@ -23,7 +23,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.2")
 
     implementation("com.android.tools.build:gradle:$androidGradlePluginVersion")
-    implementation("com.android.tools.build:bundletool:1.2.0")
+    implementation("com.android.tools.build:bundletool:1.4.0")
     implementation("org.smali:dexlib2:2.4.0")
     implementation("com.github.vidstige:jadb:v1.1.0")
 

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/AdbExtensions.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/AdbExtensions.kt
@@ -72,7 +72,7 @@ internal fun JadbDevice.installApk(timeoutMillis: Long, apk: File, vararg option
     }
 }
 
-internal fun JadbDevice.installApkSet(timeoutMillis: Long, apkSet: File, dynamicModule: String?) = IO.fx {
+internal fun JadbDevice.installApkSet(timeoutMillis: Long, apkSet: File, onDemandDynamicModuleName: String?) = IO.fx {
     val result = ioWithTimeout(timeoutMillis) {
         InstallApksCommand.fromFlags(
             FlagParser().parse(
@@ -82,7 +82,7 @@ internal fun JadbDevice.installApkSet(timeoutMillis: Long, apkSet: File, dynamic
                     "--allow-downgrade",
                     "--allow-test-only",
                     "--device-id=$serial",
-                    dynamicModule?.let { "--modules=$it" }
+                    onDemandDynamicModuleName?.let { "--modules=$it" }
                 ).toTypedArray()
             ),
             DdmlibAdbServer.getInstance()
@@ -141,7 +141,7 @@ internal fun List<JadbDevice>.reinstall(
     logger: Logger,
     applicationPackage: String?,
     instrumentationPackage: String,
-    dynamicModule: String?,
+    onDemandDynamicModuleName: String?,
     applicationAab: File?,
     signingConfig: SigningConfig,
     instrumentationApk: File,
@@ -157,7 +157,7 @@ internal fun List<JadbDevice>.reinstall(
                 if (applicationPackage != null && applicationApkSet != null) {
                     logger.lifecycle("${device.serial}: installing $applicationPackage")
                     packageManager.safeUninstall(applicationPackage)
-                    device.installApkSet(installTimeoutMillis, applicationApkSet, dynamicModule).unsafeRunSync()
+                    device.installApkSet(installTimeoutMillis, applicationApkSet, onDemandDynamicModuleName).unsafeRunSync()
                 }
 
                 logger.lifecycle("${device.serial}: installing $instrumentationPackage")

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonPlugin.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonPlugin.kt
@@ -63,6 +63,7 @@ class GordonPlugin : Plugin<Project> {
                     }
 
                     if (androidPluginType == AndroidPluginType.DYNAMIC_FEATURE) {
+                        this.dynamicFeatureModuleManifest.set(testedVariantProperties.artifacts.get(ArtifactType.MERGED_MANIFEST))
                         this.dynamicFeatureModuleName.set(project.name)
                     }
 

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonTestTask.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonTestTask.kt
@@ -137,7 +137,7 @@ internal abstract class GordonTestTask @Inject constructor(
 
             val applicationAab = applicationAab.get().asFile.takeUnless { it == PLACEHOLDER_APPLICATION_AAB }
             val applicationPackage = applicationPackage.get().takeUnless { it == PLACEHOLDER_APPLICATION_PACKAGE }
-            val dynamicModuleName = dynamicFeatureModuleName.get().takeUnless { it == PLACEHOLDER_DYNAMIC_MODULE_NAME }
+            val onDemandDynamicModuleName = dynamicFeatureModuleName.get().takeUnless { it == PLACEHOLDER_DYNAMIC_MODULE_NAME }
 
             val signingConfig = SigningConfig(
                 storeFile = signingKeystoreFile.get().asFile.takeUnless { it == PLACEHOLDER_SIGNING_KEYSTORE },
@@ -151,7 +151,7 @@ internal abstract class GordonTestTask @Inject constructor(
                 logger = logger,
                 applicationPackage = applicationPackage,
                 instrumentationPackage = instrumentationPackage.get(),
-                dynamicModule = dynamicModuleName,
+                onDemandDynamicModuleName = onDemandDynamicModuleName,
                 applicationAab = applicationAab,
                 signingConfig = signingConfig,
                 instrumentationApk = instrumentationApk,

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonTestTask.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonTestTask.kt
@@ -47,6 +47,10 @@ internal abstract class GordonTestTask @Inject constructor(
     @get:Input
     internal val signingConfigCredentials: Property<SigningConfigCredentials> = objects.property()
 
+    @get:InputFile
+    @get:PathSensitive(PathSensitivity.NAME_ONLY)
+    internal val dynamicFeatureModuleManifest: RegularFileProperty = objects.fileProperty()
+
     @get:Input
     internal val dynamicFeatureModuleName: Property<String> = objects.property()
 
@@ -105,6 +109,7 @@ internal abstract class GordonTestTask @Inject constructor(
     init {
         applicationAab.convention { PLACEHOLDER_APPLICATION_AAB }
         signingKeystoreFile.convention { PLACEHOLDER_SIGNING_KEYSTORE }
+        dynamicFeatureModuleManifest.convention { PLACEHOLDER_DYNAMIC_MODULE_MANIFEST }
         dynamicFeatureModuleName.convention(PLACEHOLDER_DYNAMIC_MODULE_NAME)
         applicationPackage.convention(PLACEHOLDER_APPLICATION_PACKAGE)
         commandlineTestFilter.convention("")
@@ -138,6 +143,7 @@ internal abstract class GordonTestTask @Inject constructor(
             val applicationAab = applicationAab.get().asFile.takeUnless { it == PLACEHOLDER_APPLICATION_AAB }
             val applicationPackage = applicationPackage.get().takeUnless { it == PLACEHOLDER_APPLICATION_PACKAGE }
             val onDemandDynamicModuleName = dynamicFeatureModuleName.get().takeUnless { it == PLACEHOLDER_DYNAMIC_MODULE_NAME }
+                .takeIf { dynamicFeatureModuleManifest.get().asFile.readText().contains("dist:on-demand") }
 
             val signingConfig = SigningConfig(
                 storeFile = signingKeystoreFile.get().asFile.takeUnless { it == PLACEHOLDER_SIGNING_KEYSTORE },
@@ -213,5 +219,6 @@ internal fun TestCase.matchesFilter(filters: List<String>): Boolean {
 
 private val PLACEHOLDER_APPLICATION_AAB = File.createTempFile("PLACEHOLDER_APPLICATION_AAB", null)
 private val PLACEHOLDER_SIGNING_KEYSTORE = File.createTempFile("PLACEHOLDER_SIGNING_KEYSTORE", null)
+private val PLACEHOLDER_DYNAMIC_MODULE_MANIFEST = File.createTempFile("PLACEHOLDER_DYNAMIC_MODULE_MANIFEST", null)
 private const val PLACEHOLDER_DYNAMIC_MODULE_NAME = "PLACEHOLDER_DYNAMIC_MODULE_NAME"
 private const val PLACEHOLDER_APPLICATION_PACKAGE = "PLACEHOLDER_APPLICATION_PACKAGE"


### PR DESCRIPTION
Fixes #73

The `--modules` argument for bundletool should only be used for on-demand modules, not install-time modules, so just check the manifest for the distribution type and proceed accordingly.