### PR TITLE
Switch from jadb to bundletool

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ pluginManagement {
         gradlePluginPortal()
         google()
         mavenCentral()
-        maven("https://www.jitpack.io")
     }
 
     plugins {
@@ -49,7 +48,6 @@ buildscript {
         gradlePluginPortal()
         google()
         mavenCentral()
-        maven { url "https://jitpack.io" }
     }
 
     dependencies {
@@ -73,7 +71,6 @@ repositories {
     gradlePluginPortal()
     google()
     mavenCentral()
-    maven("https://www.jitpack.io")
 }
 
 dependencies {

--- a/gordon-plugin/build.gradle.kts
+++ b/gordon-plugin/build.gradle.kts
@@ -27,8 +27,8 @@ dependencies {
 
     implementation("io.arrow-kt:arrow-core:0.13.2")
 
-    testImplementation("junit:junit:4.13")
-    testImplementation("org.mockito.kotlin:mockito-kotlin:3.2.0")
+    testImplementation(kotlin("test-junit"))
+    testImplementation("io.mockk:mockk:1.11.0")
 }
 
 tasks.withType<Test>().configureEach {

--- a/gordon-plugin/build.gradle.kts
+++ b/gordon-plugin/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
 repositories {
     google()
     mavenCentral()
-    maven("https://www.jitpack.io")
 }
 
 val androidGradlePluginVersion: String by project
@@ -25,7 +24,6 @@ dependencies {
     implementation("com.android.tools.build:gradle:$androidGradlePluginVersion")
     implementation("com.android.tools.build:bundletool:1.6.0")
     implementation("org.smali:dexlib2:2.5.2")
-    implementation("com.github.vidstige:jadb:v1.1.0")
 
     implementation("io.arrow-kt:arrow-core:0.13.2")
 

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/TestDistributor.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/TestDistributor.kt
@@ -1,6 +1,7 @@
 package com.banno.gordon
 
 import arrow.core.Either
+import com.android.tools.build.bundletool.device.Device
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -16,7 +17,6 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.runBlocking
 import org.gradle.api.logging.Logger
-import se.vidstige.jadb.JadbDevice
 import kotlin.coroutines.CoroutineContext
 
 internal fun runAllTests(
@@ -32,7 +32,7 @@ internal fun runAllTests(
     runBlocking {
         allPools.map { pool ->
             async(context = dispatcher, start = CoroutineStart.LAZY) {
-                val deviceSerials = pool.devices.map { it.serial }.toSet()
+                val deviceSerials = pool.devices.map { it.serialNumber }.toSet()
                 val testResults =
                     allTestCases.associateWith<TestCase, TestResult> { TestResult.NotRun }
                         .toMutableMap()
@@ -132,14 +132,14 @@ private fun CoroutineScope.runTestsInPool(
     instrumentationPackage: String,
     instrumentationRunnerOptions: InstrumentationRunnerOptions,
     testTimeoutMillis: Long,
-    devices: List<JadbDevice>,
+    devices: List<Device>,
     testDistributor: TestDistributor,
     totalTests: Int? = null
 ): List<Deferred<Map<TestCase, TestResult>>> {
     var index = 0
     return devices.map { device ->
         async(context = dispatcher, start = CoroutineStart.LAZY) {
-            testDistributor.testCasesChannel(device.serial)
+            testDistributor.testCasesChannel(device.serialNumber)
                 .consumeAsFlow()
                 .map { test ->
                     index++

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/TestRunner.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/TestRunner.kt
@@ -1,7 +1,7 @@
 package com.banno.gordon
 
+import com.android.tools.build.bundletool.device.Device
 import org.gradle.api.logging.Logger
-import se.vidstige.jadb.JadbDevice
 
 internal fun runTest(
     logger: Logger,
@@ -9,7 +9,7 @@ internal fun runTest(
     instrumentationRunnerOptions: InstrumentationRunnerOptions,
     testTimeoutMillis: Long,
     test: TestCase,
-    device: JadbDevice,
+    device: Device,
     progress: String
 ): TestResult {
     val targetInstrumentation = "$instrumentationPackage/${instrumentationRunnerOptions.testInstrumentationRunner}"
@@ -33,11 +33,11 @@ internal fun runTest(
             {
                 when (it) {
                     is AdbTimeoutException -> {
-                        logger.error("$progress -> ${device.serial}: ${test.classAndMethodName}: TIMED OUT")
-                        TestResult.Failed(null, "Test timed out", device.serial)
+                        logger.error("$progress -> ${device.serialNumber}: ${test.classAndMethodName}: TIMED OUT")
+                        TestResult.Failed(null, "Test timed out", device.serialNumber)
                     }
                     else -> {
-                        logger.error("$progress -> ${device.serial}: ${test.classAndMethodName}: UNABLE TO RUN")
+                        logger.error("$progress -> ${device.serialNumber}: ${test.classAndMethodName}: UNABLE TO RUN")
                         TestResult.NotRun
                     }
                 }
@@ -50,19 +50,19 @@ internal fun runTest(
 
             when {
                 shellOutput.matches(Regex(".*OK \\([1-9][0-9]* tests?\\)$", RegexOption.DOT_MATCHES_ALL)) -> {
-                    logger.lifecycle("$progress -> ${device.serial}: ${test.classAndMethodName}: PASSED")
+                    logger.lifecycle("$progress -> ${device.serialNumber}: ${test.classAndMethodName}: PASSED")
                     TestResult.Passed(testTime)
                 }
 
                 shellOutput.endsWith("OK (0 tests)") -> {
-                    logger.lifecycle("$progress -> ${device.serial}: ${test.classAndMethodName}: IGNORED")
+                    logger.lifecycle("$progress -> ${device.serialNumber}: ${test.classAndMethodName}: IGNORED")
                     TestResult.Ignored
                 }
 
                 else -> {
                     val failureOutput = shellOutput.substringBeforeLast("There was 1 failure")
-                    logger.error("$progress -> ${device.serial}: ${test.classAndMethodName}: FAILED\n$failureOutput\n")
-                    TestResult.Failed(testTime, failureOutput, device.serial)
+                    logger.error("$progress -> ${device.serialNumber}: ${test.classAndMethodName}: FAILED\n$failureOutput\n")
+                    TestResult.Failed(testTime, failureOutput, device.serialNumber)
                 }
             }
         }

--- a/gordon-plugin/src/test/kotlin/com/banno/gordon/AssertExtensions.kt
+++ b/gordon-plugin/src/test/kotlin/com/banno/gordon/AssertExtensions.kt
@@ -1,37 +1,5 @@
 package com.banno.gordon
 
-import org.hamcrest.CoreMatchers.equalTo
-import org.hamcrest.CoreMatchers.hasItem
-import org.hamcrest.CoreMatchers.not
-import org.hamcrest.CoreMatchers.notNullValue
-import org.hamcrest.CoreMatchers.nullValue
-import org.hamcrest.MatcherAssert.assertThat
-import org.mockito.kotlin.KStubbing
-import org.mockito.stubbing.OngoingStubbing
+import kotlin.test.assertEquals
 
-infix fun <T> T.shouldEqual(expected: T) = assertThat(this, equalTo(expected))
-
-infix fun <T> T.shouldNotEqual(expected: T) = assertThat(this, not(equalTo(expected)))
-
-infix fun <T> List<T>.shouldContain(expected: T) = assertThat(this, hasItem(expected))
-
-infix fun <T> List<T>.shouldNotContain(expected: T) = assertThat(this, not(hasItem(expected)))
-
-fun <T> List<T>.assertNotEmpty() = this.size shouldNotEqual 0
-
-fun Any?.assertNull() = assertThat(this, nullValue())
-
-fun Any?.assertNotNull() = assertThat(this, notNullValue())
-
-fun Boolean.assertTrue() = assertThat(this, equalTo(true))
-
-fun Boolean.assertFalse() = assertThat(this, equalTo(false))
-
-inline fun <reified T : Any> forMock(
-    mock: T,
-    stubbing: KStubbing<T>.(T) -> Unit
-): T = mock.apply {
-    KStubbing(this).stubbing(this)
-}
-
-fun <T> OngoingStubbing<T>.doReturnNull(): OngoingStubbing<T> = thenReturn(null)
+infix fun <T> T.shouldEqual(expected: T) = assertEquals(expected, this)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -11,7 +11,6 @@ pluginManagement {
         google()
         mavenCentral()
         mavenLocal()
-        maven("https://www.jitpack.io")
     }
 
     plugins {


### PR DESCRIPTION
### :pushpin: References

* Closes #40 

### :goal_net: What is the goal?

* Use only one library for interacting with adb instead of two

### :computer: How is it implemented?

* Switch everything that was previously done with jadb to using bundletool
* Refactor existing usages of bundletool to take the adb server as a parameter
* Get the default adb server and initialize it once at the beginning, and then pass it everywhere that needs it
