### PR TITLE
Add support for code coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,28 @@ If a retry quota is specified, Gordon will, after trying tests once, first retry
 #### Reports
 Gordon generates junit reports in the build directory / `test-results`, and an HTML report in the build directory / `reports`.
 
+#### Code Coverage
+Gordon supports creating code coverage. You can enable it by setting the `coverage` parameter:
+
+```kotlin
+android {
+    defaultConfig {
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+
+        testInstrumentationRunnerArgument("coverage", "true")
+    }
+}
+```
+
+The coverage files will be copied from the device to the build folder. The folder is based on the
+build variant and the device name:
+
+`app/build/outputs/code_coverage/gordon<BuildVariant>/connected/<DeviceName>`
+
+Example:
+`app/build/outputs/code_coverage/gordon/connected/emulator-5554`
+
+
 ## Other notes
 - See questions that have already been answered in [the Q&A category of Discussions](https://github.com/Banno/Gordon/discussions?discussions_q=category%3AQ%26A).
 - Contributions are welcome! See [the guidelines](CONTRIBUTING.md).

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/ByteArrayShellOutputReceiver.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/ByteArrayShellOutputReceiver.kt
@@ -1,0 +1,20 @@
+package com.banno.gordon
+
+import shadow.bundletool.com.android.ddmlib.IShellOutputReceiver
+
+class ByteArrayShellOutputReceiver : IShellOutputReceiver {
+    var output = ByteArray(0)
+        private set
+
+    override fun addOutput(data: ByteArray, offset: Int, length: Int) {
+        val receivedBytes = ByteArray(length)
+        System.arraycopy(data, offset, receivedBytes, 0, length)
+        output += receivedBytes
+    }
+
+    override fun flush() {
+        // NO OP
+    }
+
+    override fun isCancelled(): Boolean = false
+}

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/InstrumentationRunnerOptions.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/InstrumentationRunnerOptions.kt
@@ -8,3 +8,6 @@ internal data class InstrumentationRunnerOptions(
     val testInstrumentationRunnerArguments: Map<String, String>,
     val animationsDisabled: Boolean
 ) : java.io.Serializable
+
+internal fun InstrumentationRunnerOptions.isCoverageEnabled(): Boolean =
+    testInstrumentationRunnerArguments["coverage"] == "true"

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/ReportHandling.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/ReportHandling.kt
@@ -1,0 +1,142 @@
+package com.banno.gordon
+
+import arrow.core.Either
+import arrow.core.computations.either
+import arrow.core.flatMap
+import com.android.tools.build.bundletool.device.Device
+import com.banno.gordon.CoverageException.CoverageFileCopyException
+import com.banno.gordon.CoverageException.CoverageFileDiscoveryException
+import com.banno.gordon.CoverageException.CoverageFileNotFoundException
+import org.slf4j.Logger
+import java.io.File
+
+private const val ILLEGAL_FILE_CHARACTERS_ON_WINDOWS_REGEX = "[^a-zA-Z0-9\\\\.\\-\\s]"
+
+/**
+ * The TestCase's class and method name
+ *
+ * Example: "DummyClassTest.testMethod"
+ */
+internal val TestCase.classAndMethodName
+    get() = "${fullyQualifiedClassName.substringAfterLast('.')}.$methodName"
+
+/**
+ * The TestCase's full qualified class and method name
+ *
+ * Example: "com.example.DummyClassTest.testMethod"
+ */
+internal val TestCase.fullClassAndMethodName
+    get() = "$fullyQualifiedClassName.$methodName"
+
+/**
+ * The coverage file's name
+ *
+ * Example: "com.example.DummyClassTest.testMethod.ec"
+ */
+internal val TestCase.coverageFileName
+    get() = "$fullClassAndMethodName.ec"
+
+/**
+ * Get the path where to save coverage files on the device
+ *
+ * Example: "/data/user/0/com.example/files"
+ */
+@Suppress("SdCardPath") // We don't have access to a Context here
+fun getDeviceCoveragePathFor(userId: String, targetPackage: String) =
+    "/data/user/$userId/$targetPackage/files"
+
+/**
+ * Get the full path of a coverage file
+ *
+ * Example: "/data/user/0/com.android.example/files/com.example.DummyClassTest.testMethod.ec"
+ */
+internal fun getCoverageFileFullPath(userId: String, testedApplicationPackage: String, test: TestCase): String {
+    return "${getDeviceCoveragePathFor(userId, testedApplicationPackage)}/${test.coverageFileName}"
+}
+
+/**
+ * Replace characters that are illegal on Windows.
+ *
+ * Background: Coverage files get stored in a folder named after the device, but device names can contain characters that are illegal for directories on Windows
+ */
+internal fun String.sanitizeFileNameForWindows(): String = replace(Regex(ILLEGAL_FILE_CHARACTERS_ON_WINDOWS_REGEX), "_")
+
+sealed class CoverageException(val coverageFileFullPath: String, e: Throwable? = null) : RuntimeException(e) {
+    class CoverageFileDiscoveryException(coverageFileFullPath: String, e: Throwable) : CoverageException(coverageFileFullPath, e)
+    class CoverageFileNotFoundException(coverageFileFullPath: String) : CoverageException(coverageFileFullPath)
+    class CoverageFileCopyException(coverageFileFullPath: String, e: Throwable) : CoverageException(coverageFileFullPath, e)
+}
+
+/**
+ * Copy the coverage file with the given name from the device to the host.
+ *
+ * @param coverageFileName The coverage file's name on the device. Do not pass its full path!
+ * @return Either a `Throwable` or the absolute Path to the created local coverage file
+ */
+fun Device.copyCoverageFile(
+    buildDir: File,
+    taskName: String,
+    applicationPackage: String,
+    coverageFileName: String,
+    logger: Logger
+): Either<Throwable, String> {
+    return copyCoverageFile(buildDir, taskName, applicationPackage, coverageFileName)
+        .mapLeft { exception: Throwable ->
+            when (exception) {
+                is CoverageFileDiscoveryException -> logger.error("Could not check if the coverage file exists: ${exception.coverageFileFullPath}", exception)
+                is CoverageFileCopyException -> logger.error("Could not copy coverage file ${exception.coverageFileFullPath}", exception)
+                is CoverageFileNotFoundException -> logger.error("Coverage file not found ${exception.coverageFileFullPath}")
+                else -> logger.error("Could not determine the current user id in order to copy the coverage file $coverageFileName", exception)
+            }
+            exception
+        }.map { coverageFileFullPath: String ->
+            logger.info("Copied coverage file to $coverageFileFullPath")
+            coverageFileFullPath
+        }
+}
+
+/**
+ * Copy the coverage file with the given name from the device to the host.
+ *
+ * @param coverageFileName The coverage file's name on the device. Do not pass its full path!
+ * @return Either a `Throwable` or the absolute Path to the created local coverage file
+ */
+private fun Device.copyCoverageFile(
+    buildDir: File,
+    taskName: String,
+    applicationPackage: String,
+    coverageFileName: String
+): Either<Throwable, String> {
+    val localCoverageDirPath = "${buildDir.path}/outputs/code_coverage/$taskName/connected/${serialNumber.sanitizeFileNameForWindows()}"
+
+    return Either
+        .catch { File(localCoverageDirPath).also { it.mkdirs() } }
+        .flatMap { either.eager { getCurrentUserId().bind() } }
+        .flatMap { userId: String ->
+            val remoteCoverageDir = getDeviceCoveragePathFor(userId, applicationPackage)
+            val remoteCoverageFileFullPath = "$remoteCoverageDir/$coverageFileName".trim()
+
+            coverageFileExists(remoteCoverageFileFullPath, userId, applicationPackage)
+                .mapLeft { e: Throwable -> CoverageFileDiscoveryException(remoteCoverageFileFullPath, e) }
+                .flatMap { fileExists: Boolean ->
+                    if (!fileExists) {
+                        Either.Left(CoverageFileNotFoundException(remoteCoverageFileFullPath))
+                    } else {
+                        executeShellWithTimeoutBinaryOutput(20_000L, "run-as $applicationPackage --user $userId cat $remoteCoverageFileFullPath")
+                            .mapLeft { e: Throwable -> CoverageFileCopyException(remoteCoverageFileFullPath, e) }
+                            .map { shellOutput ->
+                                val localCoverageFile = File("$localCoverageDirPath/$coverageFileName")
+                                    .also {
+                                        it.writeBytes(shellOutput)
+                                    }
+                                localCoverageFile.absolutePath
+                            }
+                    }
+                }
+        }
+}
+
+private fun Device.coverageFileExists(fileName: String, userId: String, applicationPackage: String): Either<Throwable, Boolean> =
+    executeShellWithTimeout(20_000L, "run-as $applicationPackage --user $userId test -f $fileName; echo \$?")
+        // Check the exit code
+        .map { shellOutput -> shellOutput == "0" }

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/TestResults.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/TestResults.kt
@@ -2,6 +2,7 @@ package com.banno.gordon
 
 import kotlinx.html.* // ktlint-disable no-wildcard-imports
 import kotlinx.html.stream.appendHTML
+import org.gradle.api.logging.Logger
 
 internal sealed class TestResult {
     data class Passed(val duration: Float?) : TestResult()
@@ -58,7 +59,7 @@ internal fun Map<PoolName, Map<TestCase, TestResult>>.summary(): String {
     ).joinToString("\n")
 }
 
-internal fun Map<PoolName, Map<TestCase, TestResult>>.junitReports() =
+internal fun Map<PoolName, Map<TestCase, TestResult>>.junitReports(logger: Logger) =
     flatMap { (poolName, results) ->
         results.map { (testCase, result) ->
             val fileContent =
@@ -88,8 +89,11 @@ internal fun Map<PoolName, Map<TestCase, TestResult>>.junitReports() =
                     }
                 }
 
+            val sanitizedPoolName = poolName.sanitizeFileNameForWindows()
+            val reportFileName = "$sanitizedPoolName-${testCase.fullyQualifiedClassName}.${testCase.methodName}.xml"
+            logger.info("Creating report file: $reportFileName")
             ReportFile(
-                "$poolName-${testCase.fullyQualifiedClassName}.${testCase.methodName}.xml",
+                reportFileName,
                 fileContent
             )
         }

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/TestRunner.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/TestRunner.kt
@@ -1,18 +1,27 @@
 package com.banno.gordon
 
+import arrow.core.Either
+import arrow.core.computations.either
 import com.android.tools.build.bundletool.device.Device
 import org.gradle.api.logging.Logger
+import java.io.File
+
+private const val EXEC_TIMEOUT_MILLIS = 20_000L
 
 internal fun runTest(
     logger: Logger,
+    testedApplicationPackage: String,
     instrumentationPackage: String,
     instrumentationRunnerOptions: InstrumentationRunnerOptions,
     testTimeoutMillis: Long,
     test: TestCase,
     device: Device,
-    progress: String
+    progress: String,
+    buildDir: File,
+    taskName: String
 ): TestResult {
     val targetInstrumentation = "$instrumentationPackage/${instrumentationRunnerOptions.testInstrumentationRunner}"
+    val isCoverageEnabled = instrumentationRunnerOptions.isCoverageEnabled()
 
     val flags = listOfNotNull(
         "-w",
@@ -20,13 +29,25 @@ internal fun runTest(
     )
         .joinToString(" ")
 
-    val options = instrumentationRunnerOptions
+    var options = instrumentationRunnerOptions
         .testInstrumentationRunnerArguments
         .plus("class" to "${test.fullyQualifiedClassName}#${test.methodName}")
         .entries
         .joinToString(" ") { "-e ${it.key} ${it.value}" }
 
+    var coverageFileFullPath: String? = null
+
+    if (isCoverageEnabled) {
+        either.eager<Throwable, Unit> {
+            val userId = device.getCurrentUserId().bind()
+            device.createFilesDirFor(userId, testedApplicationPackage).bind()
+            coverageFileFullPath = getCoverageFileFullPath(userId, testedApplicationPackage, test)
+            options += " -e coverageFile $coverageFileFullPath"
+        }
+    }
+
     val command = "am instrument $flags $options $targetInstrumentation"
+    logger.info("Instrumentation command: $command")
 
     return device.executeShellWithTimeout(testTimeoutMillis, command)
         .fold(
@@ -48,13 +69,19 @@ internal fun runTest(
                 .substringBefore("\n")
                 .toFloatOrNull()
 
+            if (isCoverageEnabled) {
+                coverageFileFullPath?.let {
+                    device.copyCoverageFile(buildDir, taskName, testedApplicationPackage, test.coverageFileName, logger)
+                }
+            }
+
             when {
-                shellOutput.matches(Regex(".*OK \\([1-9][0-9]* tests?\\)$", RegexOption.DOT_MATCHES_ALL)) -> {
+                Regex("OK \\([1-9][0-9]* tests?\\)").containsMatchIn(shellOutput) -> {
                     logger.lifecycle("$progress -> ${device.serialNumber}: ${test.classAndMethodName}: PASSED")
                     TestResult.Passed(testTime)
                 }
 
-                shellOutput.endsWith("OK (0 tests)") -> {
+                shellOutput.contains("OK (0 tests)") -> {
                     logger.lifecycle("$progress -> ${device.serialNumber}: ${test.classAndMethodName}: IGNORED")
                     TestResult.Ignored
                 }
@@ -68,8 +95,11 @@ internal fun runTest(
         }
 }
 
+private fun Device.createFilesDirFor(userId: String, targetPackage: String): Either<Throwable, Unit> =
+    executeShellWithTimeout(
+        EXEC_TIMEOUT_MILLIS,
+        "run-as $targetPackage --user $userId mkdir -p ${getDeviceCoveragePathFor(userId, targetPackage)}"
+    ).void()
+
 internal fun Logger.logIgnored(test: TestCase, progress: String) =
     lifecycle("$progress -> ${test.classAndMethodName}: IGNORED")
-
-private val TestCase.classAndMethodName
-    get() = "${fullyQualifiedClassName.substringAfterLast('.')}.$methodName"

--- a/gordon-plugin/src/test/kotlin/com/banno/gordon/DeviceMock.kt
+++ b/gordon-plugin/src/test/kotlin/com/banno/gordon/DeviceMock.kt
@@ -1,0 +1,92 @@
+package com.banno.gordon
+
+import arrow.core.Either
+import com.android.tools.build.bundletool.device.Device
+import io.mockk.CapturingSlot
+import io.mockk.MockKMatcherScope
+import io.mockk.MockKStubScope
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import shadow.bundletool.com.android.ddmlib.IShellOutputReceiver
+import java.util.UUID
+
+fun anyDevice(
+    serial: String = UUID.randomUUID().toString(),
+    isTablet: Boolean = false,
+    tabletShortestWidthDp: Int? = null,
+    currentUserId: Int = 0
+): Device = mockk {
+    every { serialNumber } returns serial
+    mockCurrentUserId(currentUserId)
+
+    val shellOutputSlot = slot<IShellOutputReceiver>()
+
+    fun MockKStubScope<Unit, Unit>.answersShellOutput(shellOutput: String) = answers {
+        shellOutputSlot.captured.addOutput(shellOutput.toByteArray(), 0, shellOutput.length)
+    }
+
+    every {
+        executeShellCommand("getprop ro.build.characteristics", capture(shellOutputSlot), any(), any())
+    }.answersShellOutput(if (isTablet) "tablet" else " phone")
+
+    every {
+        executeShellCommand("wm size", capture(shellOutputSlot), any(), any())
+    }.answersShellOutput("Physical size: ${tabletShortestWidthDp}x$tabletShortestWidthDp")
+
+    every {
+        executeShellCommand("wm density", capture(shellOutputSlot), any(), any())
+    }.answersShellOutput("Physical density: 160")
+}
+
+fun Device.mockResponse(command: MockKMatcherScope.() -> String, response: () -> String) {
+    val shellOutputSlot = slot<IShellOutputReceiver>()
+    every {
+        executeShellCommand(command(), capture(shellOutputSlot), any(), any())
+    }.answersShellOutput(shellOutputSlot, response())
+}
+
+fun MockKStubScope<Unit, Unit>.answersShellOutput(shellOutputSlot: CapturingSlot<IShellOutputReceiver>, shellOutput: String) = answers {
+    shellOutputSlot.captured.addOutput(shellOutput.toByteArray(), 0, shellOutput.length)
+}
+
+fun Device.mockCurrentUserId(userId: Int) {
+    mockResponse({ match { it.contains("am get-current-user") } }) { "$userId" }
+}
+
+fun Device.mockCoverageFileExists(applicationPackage: String, userId: Int, fileName: String, fileExists: Boolean = true) {
+    mockResponse({ match { it.isFileExistsCheck(applicationPackage, userId, fileName) } }) {
+        if (fileExists) "0" else "1"
+    }
+}
+
+fun Device.mockCoverageFileExistsException(applicationPackage: String, userId: Int, fileName: String) {
+    mockkStatic(Device::executeShellWithTimeout)
+    every {
+        executeShellWithTimeout(any(), match { it.isFileExistsCheck(applicationPackage, userId, fileName) })
+    } returns Either.Left(shadow.bundletool.com.android.ddmlib.TimeoutException())
+}
+
+fun Device.mockCoverageFile(applicationPackage: String, userId: Int, fileName: String, coverageFileContent: ByteArray) {
+    mockkStatic(Device::executeShellWithTimeoutBinaryOutput)
+    mockCoverageFileExists(applicationPackage, userId, fileName)
+
+    every {
+        executeShellWithTimeoutBinaryOutput(any(), match { it.isCopyCoverageFileCommand(applicationPackage, userId) })
+    } returns Either.Right(coverageFileContent)
+}
+
+fun Device.mockCoverageFileCopyException(applicationPackage: String, userId: Int, fileName: String) {
+    mockkStatic(Device::executeShellWithTimeoutBinaryOutput)
+    mockCoverageFileExists(applicationPackage, userId, fileName)
+    every {
+        executeShellWithTimeoutBinaryOutput(any(), match { it.isCopyCoverageFileCommand(applicationPackage, userId) })
+    } returns Either.Left(shadow.bundletool.com.android.ddmlib.TimeoutException())
+}
+
+private fun String.isFileExistsCheck(applicationPackage: String, userId: Int, fileName: String): Boolean =
+    contains("run-as $applicationPackage --user $userId test -f") && contains(fileName)
+
+private fun String.isCopyCoverageFileCommand(applicationPackage: String, userId: Int): Boolean =
+    contains("run-as $applicationPackage --user $userId cat")

--- a/gordon-plugin/src/test/kotlin/com/banno/gordon/ReportHandlingKtTest.kt
+++ b/gordon-plugin/src/test/kotlin/com/banno/gordon/ReportHandlingKtTest.kt
@@ -1,0 +1,167 @@
+package com.banno.gordon
+
+import arrow.core.Either
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.Assert.assertArrayEquals
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.TemporaryFolder
+import org.slf4j.Logger
+import java.io.File
+
+class ReportHandlingKtTest {
+
+    @get:Rule
+    val temporaryFolder = TemporaryFolder()
+
+    @Test
+    fun `should replace illegal characters in relative file names`() {
+        // GIVEN
+        val relativeFilePath = "some user\\some_dir\\invalid:folder\\invalid:file.log"
+        val expectedFilePath = "some user\\some_dir\\invalid_folder\\invalid_file.log"
+
+        // WHEN
+        val sanitizedFilePath = relativeFilePath.sanitizeFileNameForWindows()
+
+        // THEN
+        assertEquals(expectedFilePath, sanitizedFilePath)
+    }
+
+    @Test
+    fun `should replace illegal characters in relative file names in unix paths`() {
+        // GIVEN
+        val relativeUnixFilePath = "some:file.log"
+        val expectedFilePath = "some_file.log"
+
+        // WHEN
+        val sanitizedFilePath = relativeUnixFilePath.sanitizeFileNameForWindows()
+
+        // THEN
+        assertEquals(expectedFilePath, sanitizedFilePath)
+    }
+
+    @Test
+    fun `should copy coverage files correctly from the device to the host`() {
+        // GIVEN
+        val deviceName = "emulator-5554"
+        val device = anyDevice(deviceName)
+        val buildDir = temporaryFolder.newFolder()
+        val gradleTaskName = "gordon"
+        val applicationPackage = "com.example.package"
+        val coverageFileName = "com.example.package.class.methodname.ec"
+        val localCoverageFilePath = "${buildDir.path}/outputs/code_coverage/$gradleTaskName/connected/$deviceName/$coverageFileName"
+        val coverageFileContent = ByteArray(4) { 0 }
+
+        device.mockCoverageFile(applicationPackage, 0, coverageFileName, coverageFileContent)
+
+        // WHEN
+        val copyResult: Either<Throwable, String> = device.copyCoverageFile(
+            buildDir,
+            gradleTaskName,
+            applicationPackage,
+            coverageFileName,
+            mockk(relaxed = true)
+        )
+
+        // THEN
+        assertTrue(copyResult.isRight())
+
+        val coverageFile = File(localCoverageFilePath)
+        assertTrue(coverageFile.exists())
+        assertArrayEquals(coverageFileContent, coverageFile.readBytes())
+    }
+
+    @Test
+    fun `should fail when checking if the given coverage file exists fails`() {
+        // GIVEN
+        val deviceName = "emulator-5554"
+        val device = anyDevice(deviceName)
+        val buildDir = temporaryFolder.newFolder()
+        val gradleTaskName = "gordon"
+        val applicationPackage = "com.example.package"
+        val coverageFileName = "com.example.package.class.methodname.ec"
+        val localCoverageFilePath = "${buildDir.path}/outputs/code_coverage/$gradleTaskName/connected/$deviceName/$coverageFileName"
+        val logger = mockk<Logger>(relaxed = true)
+
+        device.mockCoverageFileExistsException(applicationPackage, 0, coverageFileName)
+
+        // WHEN
+        val copyResult: Either<Throwable, String> = device.copyCoverageFile(
+            buildDir,
+            gradleTaskName,
+            applicationPackage,
+            coverageFileName,
+            logger
+        )
+
+        // THEN
+        verify { logger.error(match { it.contains("Could not check if the coverage file exists") }, any<Throwable>()) }
+
+        assertTrue(copyResult.isLeft())
+        assertFalse(File(localCoverageFilePath).exists())
+    }
+
+    @Test
+    fun `should fail when the given coverage file does not exist on the device`() {
+        // GIVEN
+        val deviceName = "emulator-5554"
+        val device = anyDevice(deviceName)
+        val buildDir = temporaryFolder.newFolder()
+        val gradleTaskName = "gordon"
+        val applicationPackage = "com.example.package"
+        val coverageFileName = "com.example.package.class.methodname.ec"
+        val localCoverageFilePath = "${buildDir.path}/outputs/code_coverage/$gradleTaskName/connected/$deviceName/$coverageFileName"
+        val logger = mockk<Logger>(relaxed = true)
+
+        device.mockCoverageFileExists(applicationPackage, 0, coverageFileName, fileExists = false)
+
+        // WHEN
+        val copyResult: Either<Throwable, String> = device.copyCoverageFile(
+            buildDir,
+            gradleTaskName,
+            applicationPackage,
+            coverageFileName,
+            logger
+        )
+
+        // THEN
+        verify { logger.error(match { it.contains("Coverage file not found") }) }
+
+        assertTrue(copyResult.isLeft())
+        assertFalse(File(localCoverageFilePath).exists())
+    }
+
+    @Test
+    fun `should fail when copying the given coverage file fails`() {
+        // GIVEN
+        val deviceName = "emulator-5554"
+        val device = anyDevice(deviceName)
+        val buildDir = temporaryFolder.newFolder()
+        val gradleTaskName = "gordon"
+        val applicationPackage = "com.example.package"
+        val coverageFileName = "com.example.package.class.methodname.ec"
+        val localCoverageFilePath = "${buildDir.path}/outputs/code_coverage/$gradleTaskName/connected/$deviceName/$coverageFileName"
+        val logger = mockk<Logger>(relaxed = true)
+
+        device.mockCoverageFileCopyException(applicationPackage, 0, coverageFileName)
+
+        // WHEN
+        val copyResult: Either<Throwable, String> = device.copyCoverageFile(
+            buildDir,
+            gradleTaskName,
+            applicationPackage,
+            coverageFileName,
+            logger
+        )
+
+        // THEN
+        verify { logger.error(match { it.contains("Could not copy coverage file") }, any<Throwable>()) }
+
+        assertTrue(copyResult.isLeft())
+        assertFalse(File(localCoverageFilePath).exists())
+    }
+}

--- a/gordon-plugin/src/test/kotlin/com/banno/gordon/TestDistributionTest.kt
+++ b/gordon-plugin/src/test/kotlin/com/banno/gordon/TestDistributionTest.kt
@@ -14,9 +14,13 @@ import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import org.junit.Test
 import shadow.bundletool.com.android.ddmlib.IShellOutputReceiver
+import java.io.File
 import java.util.UUID
 
 class TestDistributionTest {
+
+    private val buildDir = File("build")
+    private val taskName = "gordon"
 
     @Test
     fun shouldRunTestSuiteAcrossAllPools() {
@@ -56,12 +60,15 @@ class TestDistributionTest {
         val actual = runAllTests(
             dispatcher = Dispatchers.IO,
             logger = mockk(relaxed = true),
-            instrumentationPackage = "instrumentationPackage",
+            testedApplicationPackage = "com.example.app",
+            instrumentationPackage = "com.example.app.test",
             instrumentationRunnerOptions = anyInstrumentationRunnerOptions(),
             allTestCases = testSuite,
             allPools = pools,
             retryQuota = 0,
-            testTimeoutMillis = 1000
+            testTimeoutMillis = 1000,
+            buildDir = buildDir,
+            taskName = taskName
         ).orNull()
 
         actual shouldEqual mapOf(
@@ -110,12 +117,15 @@ class TestDistributionTest {
         val actual = runAllTests(
             dispatcher = Dispatchers.IO,
             logger = mockk(relaxed = true),
-            instrumentationPackage = "instrumentationPackage",
+            testedApplicationPackage = "com.example.app",
+            instrumentationPackage = "com.example.app.test",
             instrumentationRunnerOptions = anyInstrumentationRunnerOptions(),
             allTestCases = testSuite,
             allPools = pools,
             retryQuota = 1,
-            testTimeoutMillis = 1000
+            testTimeoutMillis = 1000,
+            buildDir = buildDir,
+            taskName = taskName
         ).orNull()
 
         actual shouldEqual mapOf(
@@ -145,12 +155,15 @@ class TestDistributionTest {
         val actual = runAllTests(
             dispatcher = Dispatchers.IO,
             logger = mockk(relaxed = true),
-            instrumentationPackage = "instrumentationPackage",
+            testedApplicationPackage = "com.example.app",
+            instrumentationPackage = "com.example.app.test",
             instrumentationRunnerOptions = anyInstrumentationRunnerOptions(),
             allTestCases = testSuite,
             allPools = pools,
             retryQuota = 1,
-            testTimeoutMillis = 1000
+            testTimeoutMillis = 1000,
+            buildDir = buildDir,
+            taskName = taskName
         ).orNull()
 
         actual shouldEqual mapOf(
@@ -182,12 +195,15 @@ class TestDistributionTest {
         val actual = runAllTests(
             dispatcher = Dispatchers.IO,
             logger = mockk(relaxed = true),
-            instrumentationPackage = "instrumentationPackage",
+            testedApplicationPackage = "com.example.app",
+            instrumentationPackage = "com.example.app.test",
             instrumentationRunnerOptions = anyInstrumentationRunnerOptions(),
             allTestCases = testSuite,
             allPools = pools,
             retryQuota = 2,
-            testTimeoutMillis = 1000
+            testTimeoutMillis = 1000,
+            buildDir = buildDir,
+            taskName = taskName
         ).orNull()
 
         actual shouldEqual mapOf(
@@ -219,12 +235,15 @@ class TestDistributionTest {
         val actual = runAllTests(
             dispatcher = Dispatchers.IO,
             logger = mockk(relaxed = true),
-            instrumentationPackage = "instrumentationPackage",
+            testedApplicationPackage = "com.example.app",
+            instrumentationPackage = "com.example.app.test",
             instrumentationRunnerOptions = anyInstrumentationRunnerOptions(),
             allTestCases = testSuite,
             allPools = pools,
             retryQuota = 2,
-            testTimeoutMillis = 1000
+            testTimeoutMillis = 1000,
+            buildDir = buildDir,
+            taskName = taskName
         ).orNull()
 
         actual shouldEqual mapOf(
@@ -261,12 +280,15 @@ class TestDistributionTest {
         runAllTests(
             dispatcher = Dispatchers.IO,
             logger = mockk(relaxed = true),
-            instrumentationPackage = "instrumentationPackage",
+            testedApplicationPackage = "com.example.app",
+            instrumentationPackage = "com.example.app.test",
             instrumentationRunnerOptions = anyInstrumentationRunnerOptions(),
             allTestCases = testSuite,
             allPools = pools,
             retryQuota = 1,
-            testTimeoutMillis = 1000
+            testTimeoutMillis = 1000,
+            buildDir = buildDir,
+            taskName = taskName
         )
 
         verify(exactly = 1) { device.executeShellCommand(match { it.contains("A#methodOne") }, any(), any(), any()) }
@@ -291,12 +313,15 @@ class TestDistributionTest {
         val actual = runAllTests(
             dispatcher = Dispatchers.IO,
             logger = mockk(relaxed = true),
-            instrumentationPackage = "instrumentationPackage",
+            testedApplicationPackage = "com.example.app",
+            instrumentationPackage = "com.example.app.test",
             instrumentationRunnerOptions = anyInstrumentationRunnerOptions(),
             allTestCases = testSuite,
             allPools = pools,
             retryQuota = 1,
-            testTimeoutMillis = 1000
+            testTimeoutMillis = 1000,
+            buildDir = buildDir,
+            taskName = taskName
         ).orNull()
 
         actual shouldEqual mapOf(
@@ -321,12 +346,15 @@ class TestDistributionTest {
         val actual = runAllTests(
             dispatcher = Dispatchers.IO,
             logger = mockk(relaxed = true),
-            instrumentationPackage = "instrumentationPackage",
+            testedApplicationPackage = "com.example.app",
+            instrumentationPackage = "com.example.app.test",
             instrumentationRunnerOptions = anyInstrumentationRunnerOptions(),
             allTestCases = testSuite,
             allPools = pools,
             retryQuota = 1,
-            testTimeoutMillis = 1000
+            testTimeoutMillis = 1000,
+            buildDir = buildDir,
+            taskName = taskName
         ).orNull()
 
         actual shouldEqual mapOf(
@@ -356,12 +384,15 @@ class TestDistributionTest {
         val actual = runAllTests(
             dispatcher = Dispatchers.IO,
             logger = mockk(relaxed = true),
-            instrumentationPackage = "instrumentationPackage",
+            testedApplicationPackage = "com.example.app",
+            instrumentationPackage = "com.example.app.test",
             instrumentationRunnerOptions = anyInstrumentationRunnerOptions(),
             allTestCases = testSuite,
             allPools = pools,
             retryQuota = 3,
-            testTimeoutMillis = 1000
+            testTimeoutMillis = 1000,
+            buildDir = buildDir,
+            taskName = taskName
         ).orNull()
 
         actual shouldEqual mapOf(
@@ -392,12 +423,15 @@ class TestDistributionTest {
         val actual = runAllTests(
             dispatcher = Dispatchers.IO,
             logger = mockk(relaxed = true),
-            instrumentationPackage = "instrumentationPackage",
+            testedApplicationPackage = "com.example.app",
+            instrumentationPackage = "com.example.app.test",
             instrumentationRunnerOptions = anyInstrumentationRunnerOptions(),
             allTestCases = testSuite,
             allPools = pools,
             retryQuota = 1,
-            testTimeoutMillis = 1000
+            testTimeoutMillis = 1000,
+            buildDir = buildDir,
+            taskName = taskName
         ).orNull()
 
         actual shouldEqual mapOf(

--- a/gordon-plugin/src/test/kotlin/com/banno/gordon/TestRunnerKtTest.kt
+++ b/gordon-plugin/src/test/kotlin/com/banno/gordon/TestRunnerKtTest.kt
@@ -1,0 +1,93 @@
+package com.banno.gordon
+
+import io.mockk.mockk
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class TestRunnerKtTest {
+
+    private val testTimeout = 2000L
+    private val device = anyDevice()
+
+    private val buildDir = File("build")
+    private val taskName = "gordon"
+
+    @Test
+    fun `should identify a passed test correctly`() {
+        // GIVEN
+        device.mockResponse({ match { it.contains("am instrument") } }) {
+            """
+                com.example.app.ui.ExampleFragmentTest:.
+
+                Time: 1.562
+
+                OK (1 test)
+
+
+                Generated code coverage data to /data/user/10/com.example.app/files/should_show_something.ec
+            """.trimIndent()
+        }
+
+        // WHEN
+        val testResult = runTest()
+
+        // THEN
+        assertTrue(testResult is TestResult.Passed)
+    }
+
+    @Test
+    fun `should identify ignored tests correctly`() {
+        // GIVEN
+        device.mockResponse({ match { it.contains("am instrument") } }) {
+            """
+            Time: 0
+
+            OK (0 tests)
+
+
+            Generated code coverage data to /data/user/10/com.example.app/files/ignored_test.ec"
+
+            """.trimIndent()
+        }
+
+        // WHEN
+        val testResult = runTest()
+
+        // THEN
+        assertTrue(testResult is TestResult.Ignored)
+    }
+
+    @Test
+    fun `should treat any other result as a failure`() {
+        // GIVEN
+        device.mockResponse({ match { it.contains("am instrument") } }) {
+            """
+            Lorem ipsum
+            """.trimIndent()
+        }
+
+        // WHEN
+        val testResult = runTest()
+
+        // THEN
+        assertTrue(testResult is TestResult.Failed)
+    }
+
+    private fun runTest(): TestResult = runTest(
+        logger = mockk(relaxed = true),
+        testedApplicationPackage = "com.example.app",
+        instrumentationPackage = "com.example.app.test",
+        InstrumentationRunnerOptions("androidx.test.runner.AndroidJUnitRunner", mapOf("coverage" to "true"), true),
+        testTimeout,
+        TestCase(
+            "class com.example.app.ui.ExampleFragmentTest",
+            "should_show_something",
+            false
+        ),
+        device,
+        "",
+        buildDir,
+        taskName
+    )
+}


### PR DESCRIPTION
on-behalf-of: @e-solutions-GmbH <info@esolutions.de>

### :goal_net: What is the goal?

Add support for generating and downloading code coverage files when running tests with Gordon on both Standard Android and Android Automotive.

### :computer: How is it implemented?

Creating the coverage files is already part of AndroidJUnitRunner and can be used e.g. with the Android Test Orchestrator. This PR adds support so that Gordon
* passes the "coverage" flag through with an according file name
* copies the generated *.ec files from the device to the host machine after the test run.

For us, it's especially important that this code works on Android Automotive (which is a multi-user environment). That means that this PR is built to be aware under which user the tests run, storing and copying the coverage files in/from the correct user data folder (e.g. data/user/10/... per default on Android Automotive instead of /data/user/0/...).

I am looking forward to your comments! Thank you very much for building and open-sourcing Gordon!