### PR TITLE
Support non-default testBuildType

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,16 +165,14 @@ In this example, the AndroidX `AndroidJUnitRunner` will be used, animations will
 ## Running
 
 #### Tasks
-Gordon registers a Gradle task for each tested variant, stripping `Debug` from the task name because it's redundant.
+Gordon registers a Gradle task for each tested variant, stripping `testBuildType` (normally `Debug`) from the task name because it's redundant.
 
 For example, if you have no flavors defined, the following task is registered:
 - `gordon` - the equivalent of `connectedDebugAndroidTest`
 
-If you have a `mode` dimension with `demo` and `full` flavors, plus a `staging` build type in addition to the standard `debug` and `release` types, the following tasks are registered:
-- `gordonDemo` - the equivalent of `connectedDemoDebugAndroidTest`
-- `gordonFull` - the equivalent of `connectedFullDebugAndroidTest`
-- `gordonDemoStaging` - the equivalent of `connectedDemoStagingAndroidTest`
-- `gordonFullStaging` - the equivalent of `connectedFullStagingAndroidTest`
+If you have a `mode` dimension with `demo` and `full` flavors, plus a `staging` build type in addition to the standard `debug` and `release` types, and you set your `testBuildType` to `staging`, the following tasks are registered:
+- `gordonDemo` - the equivalent of `connectedDemoStagingAndroidTest`
+- `gordonFull` - the equivalent of `connectedFullStagingAndroidTest`
 
 #### Filtering
 There is a `--tests` commandline option that overrides the `testFilter` set in the `gordon` extension if both are specified.

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonPlugin.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonPlugin.kt
@@ -30,12 +30,13 @@ class GordonPlugin : Plugin<Project> {
 
         fun registerGordonTask(
             androidTestVariant: AndroidTest,
+            testBuildType: String,
             configuration: (GordonTestTask) -> Unit
         ) {
             val variantTaskName = androidTestVariant.name
                 .capitalize(Locale.ROOT)
                 .replace(Regex("AndroidTest$"), "")
-                .replace(Regex("Debug$"), "")
+                .replace(Regex("${testBuildType.capitalize(Locale.ROOT)}$"), "")
 
             project.tasks.register<GordonTestTask>("gordon$variantTaskName") {
                 group = VERIFICATION_GROUP
@@ -102,7 +103,7 @@ class GordonPlugin : Plugin<Project> {
         when (androidPlugin) {
             is AndroidPlugin.App -> androidPlugin.componentsExtension.onVariants { applicationVariant ->
                 applicationVariant.androidTest?.let { androidTestVariant ->
-                    registerGordonTask(androidTestVariant) { gordonTask ->
+                    registerGordonTask(androidTestVariant, testedExtension.testBuildType) { gordonTask ->
                         val testedVariant = testedExtension.testVariants.single { it.name == androidTestVariant.name }.testedVariant as ApkVariant
 
                         configureGordonTask(
@@ -121,7 +122,7 @@ class GordonPlugin : Plugin<Project> {
             }
             is AndroidPlugin.DynamicFeature -> androidPlugin.componentsExtension.onVariants { dynamicFeatureVariant ->
                 dynamicFeatureVariant.androidTest?.let { androidTestVariant ->
-                    registerGordonTask(androidTestVariant) { gordonTask ->
+                    registerGordonTask(androidTestVariant, testedExtension.testBuildType) { gordonTask ->
                         val testedVariant = testedExtension.testVariants.single { it.name == androidTestVariant.name }.testedVariant as ApkVariant
 
                         val (appProject, appVariant) = appDependencyOfFeature(project, testedVariant)
@@ -145,7 +146,7 @@ class GordonPlugin : Plugin<Project> {
             }
             is AndroidPlugin.Library -> androidPlugin.componentsExtension.onVariants { libraryVariant ->
                 libraryVariant.androidTest?.let { androidTestVariant ->
-                    registerGordonTask(androidTestVariant) { gordonTask ->
+                    registerGordonTask(androidTestVariant, testedExtension.testBuildType) { gordonTask ->
                         val testedVariant = testedExtension.testVariants.single { it.name == androidTestVariant.name }.testedVariant
 
                         configureGordonTask(


### PR DESCRIPTION

### :goal_net: What is the goal?

* More consistent task names for non-default `testBuildType`
* See README changes for the effect this will have

### :computer: How is it implemented?

* Strip `testBuildType` from task name instead only stripping `Debug` (which is the default)