### PR TITLE
Support Gradle configuration cache

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
-        java-version: 11
+        java-version: 17
 
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     - uses: actions/setup-java@v3
       with:
         distribution: 'zulu'
-        java-version: 11
+        java-version: 17
 
     - uses: actions/checkout@v3
 

--- a/gordon-plugin/build.gradle.kts
+++ b/gordon-plugin/build.gradle.kts
@@ -1,15 +1,10 @@
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
 plugins {
     `kotlin-dsl`
-    `java-gradle-plugin`
     id("com.gradle.plugin-publish")
-    `maven-publish`
     kotlin("plugin.serialization")
     id("org.jmailen.kotlinter")
-}
-
-repositories {
-    google()
-    mavenCentral()
 }
 
 val androidGradlePluginVersion: String by project
@@ -18,11 +13,11 @@ val aapt2Version: String by project
 dependencies {
     implementation(gradleKotlinDsl())
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.4.3")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.3.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
     implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.3")
 
     implementation("com.android.tools.build:gradle:$androidGradlePluginVersion")
-    implementation("com.android.tools.build:bundletool:1.8.2")
+    implementation("com.android.tools.build:bundletool:1.14.1")
     implementation("com.google.guava:guava:30.1.1-jre")
     implementation("org.smali:dexlib2:2.5.2")
 
@@ -30,6 +25,12 @@ dependencies {
 
     testImplementation(kotlin("test-junit"))
     testImplementation("io.mockk:mockk:1.12.0")
+}
+
+tasks.withType<KotlinCompile>().configureEach {
+    kotlinOptions {
+        jvmTarget = "17"
+    }
 }
 
 tasks.withType<Test>().configureEach {
@@ -49,20 +50,17 @@ mapOf(
 }
 
 gradlePlugin {
+    website.set("https://github.com/Banno/Gordon")
+    vcsUrl.set("https://github.com/Banno/Gordon")
     plugins {
         register("gordon") {
             id = "com.banno.gordon"
             implementationClass = "com.banno.gordon.GordonPlugin"
             displayName = "Gordon"
             description = "Android instrumentation test runner designed for speed, simplicity, and reliability"
+            tags.set(setOf("android", "instrumentation", "test", "runner"))
         }
     }
-}
-
-pluginBundle {
-    website = "https://github.com/Banno/Gordon"
-    vcsUrl = "https://github.com/Banno/Gordon"
-    tags = setOf("android", "instrumentation", "test", "runner")
 }
 
 extra["gradle.publish.key"] = System.getenv("GRADLE_PLUGIN_PUBLISH_KEY")

--- a/gordon-plugin/gradle.properties
+++ b/gordon-plugin/gradle.properties
@@ -1,2 +1,2 @@
 group=com.banno.gordon
-version=1.8.8
+version=1.9.0

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/DevicePools.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/DevicePools.kt
@@ -20,11 +20,11 @@ internal fun calculatePools(
     val allDevices = adb.getAllDevices().bind()
 
     when (strategy) {
-        PoolingStrategy.PoolPerDevice -> allDevices.map { DevicePool(it.serialNumber, listOf(it)) }
+        is PoolingStrategy.PoolPerDevice -> allDevices.map { DevicePool(it.serialNumber, listOf(it)) }
 
-        PoolingStrategy.SinglePool -> listOf(DevicePool("All-Devices", allDevices.toList()))
+        is PoolingStrategy.SinglePool -> listOf(DevicePool("All-Devices", allDevices.toList()))
 
-        PoolingStrategy.PhonesAndTablets -> {
+        is PoolingStrategy.PhonesAndTablets -> {
             val deviceAndIsTablet = allDevices.map { it to it.isTablet(tabletShortestWidthDp).bind() }
 
             listOf(

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/TestDistributor.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/TestDistributor.kt
@@ -93,7 +93,7 @@ internal fun runAllTests(
                                 val existingResult = testResults[testCase]
 
                                 when (result) {
-                                    TestResult.NotRun -> if (existingResult is TestResult.Failed) existingResult else result
+                                    is TestResult.NotRun -> if (existingResult is TestResult.Failed) existingResult else result
 
                                     is TestResult.Failed -> {
                                         if (existingResult is TestResult.Failed) {
@@ -112,7 +112,7 @@ internal fun runAllTests(
                                     }
 
                                     is TestResult.Flaky,
-                                    TestResult.Ignored -> result
+                                    is TestResult.Ignored -> result
                                 }
                             }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,9 +1,10 @@
-androidGradlePluginVersion=7.1.1
-aapt2Version=7.1.1-7984345
-kotlinVersion=1.6.10
+androidGradlePluginVersion=8.0.0
+aapt2Version=8.0.0-9289358
+kotlinVersion=1.8.10
 kotlinterVersion=3.8.0
-gradlePluginPublishVersion=0.20.0
+gradlePluginPublishVersion=1.2.0
 org.gradle.caching=true
+org.gradle.configuration-cache=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx1536m
 org.gradle.parallel=true

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-all.zip

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -23,3 +23,12 @@ pluginManagement {
         id("com.gradle.plugin-publish") version gradlePluginPublishVersion
     }
 }
+
+dependencyResolutionManagement {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+enableFeaturePreview("STABLE_CONFIGURATION_CACHE")

--- a/test_app/build.gradle.kts
+++ b/test_app/build.gradle.kts
@@ -6,15 +6,23 @@ plugins {
 }
 
 android {
-    compileSdk = 31
-    buildToolsVersion = "31.0.0"
+    namespace = "com.banno.android.gordontest"
+    compileSdk = 33
+    buildToolsVersion = "33.0.2"
     defaultConfig {
-        minSdk = 21
-        targetSdk = 31
+        minSdk = 26
+        targetSdk = 33
         applicationId = "com.banno.android.gordontest"
         versionCode = 1
         versionName = "1.0"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+    compileOptions {
+        sourceCompatibility("17")
+        targetCompatibility("17")
+    }
+    kotlinOptions {
+        jvmTarget = "17"
     }
     val debugSigningConfig = signingConfigs.register("debugSigningConfig") {
         storeFile = file("debug.keystore")
@@ -28,11 +36,6 @@ android {
     dynamicFeatures.add(
         ":test_feature"
     )
-}
-
-repositories {
-    google()
-    mavenCentral()
 }
 
 dependencies {

--- a/test_app/src/main/AndroidManifest.xml
+++ b/test_app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.banno.android.gordontest">
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
         android:icon="@android:mipmap/sym_def_app_icon"

--- a/test_feature/build.gradle.kts
+++ b/test_feature/build.gradle.kts
@@ -6,17 +6,20 @@ plugins {
 }
 
 android {
-    compileSdk = 31
-    buildToolsVersion = "31.0.0"
+    namespace = "com.banno.android.gordontest.feature"
+    compileSdk = 33
+    buildToolsVersion = "33.0.2"
     defaultConfig {
-        minSdk = 21
+        minSdk = 26
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
-}
-
-repositories {
-    google()
-    mavenCentral()
+    compileOptions {
+        sourceCompatibility("17")
+        targetCompatibility("17")
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
 }
 
 dependencies {

--- a/test_feature/src/main/AndroidManifest.xml
+++ b/test_feature/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest
-    xmlns:dist="http://schemas.android.com/apk/distribution"
-    package="com.banno.android.gordontest.feature">
+    xmlns:dist="http://schemas.android.com/apk/distribution">
 
     <dist:module
         dist:instant="false"

--- a/test_library/build.gradle.kts
+++ b/test_library/build.gradle.kts
@@ -6,12 +6,19 @@ plugins {
 }
 
 android {
-    compileSdk = 31
-    buildToolsVersion = "31.0.0"
+    namespace = "com.banno.android.gordontest.library"
+    compileSdk = 33
+    buildToolsVersion = "33.0.2"
     defaultConfig {
-        minSdk = 21
-        targetSdk = 31
+        minSdk = 26
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+    compileOptions {
+        sourceCompatibility("17")
+        targetCompatibility("17")
+    }
+    kotlinOptions {
+        jvmTarget = "17"
     }
     flavorDimensions.add("foo")
     productFlavors {
@@ -23,11 +30,6 @@ android {
             testInstrumentationRunnerArguments["notAnnotation"] = "org.junit.Test"
         }
     }
-}
-
-repositories {
-    google()
-    mavenCentral()
 }
 
 dependencies {

--- a/test_library/src/main/AndroidManifest.xml
+++ b/test_library/src/main/AndroidManifest.xml
@@ -1,2 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.banno.android.gordontest.library"/>


### PR DESCRIPTION
### :pushpin: References

* Closes #50

### :goal_net: What is the goal?

* Update Gradle, Kotlin, Java, AGP, publishing plugin, bundletool, etc
* Support [Gradle configuration cache](https://docs.gradle.org/current/userguide/configuration_cache.html)

### :computer: How is it implemented?

* With the latest Gradle version, the only change required to support configuration caching was fixing a problem with deserializing sealed class types used as task inputs. Gradle uses its own serialization model for configuration caching, and for some reason, sealed class `object` subtypes were getting deserialized as some instance of the object. The fix was just to always use `is` checks instead of `==` or the implicit `===` used is `when` statements.