### PR TITLE
Support junit5 Test annotation

### DIFF
--- a/gordon-plugin/gradle.properties
+++ b/gordon-plugin/gradle.properties
@@ -1,2 +1,2 @@
 group=com.banno.gordon
-version=1.9.3
+version=1.10.0

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/TestSuiteLoader.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/TestSuiteLoader.kt
@@ -50,4 +50,4 @@ private val Annotatable.isIgnored
     get() = annotationNames.any { it == "org.junit.Ignore" }
 
 private val Annotatable.isTestMethod
-    get() = annotationNames.any { it == "org.junit.Test" }
+    get() = annotationNames.intersect(setOf("org.junit.Test", "org.junit.jupiter.api.Test")).isNotEmpty()


### PR DESCRIPTION
### :pushpin: References

Closes #124

### :goal_net: What is the goal?

* Support tests annotated with the junit5 / jupiter `@Test` annotation

### :computer: How is it implemented?

* Update `isTestMethod` extension to check for junit 4 and 5 versions of the `@Test` annotation
