### PR TITLE
Add '-g' to install flags

### DIFF
--- a/gordon-plugin/build.gradle.kts
+++ b/gordon-plugin/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-html:0.7.3")
 
     implementation("com.android.tools.build:gradle:$androidGradlePluginVersion")
-    implementation("com.android.tools.build:bundletool:1.14.1")
+    implementation("com.android.tools.build:bundletool:1.15.6")
     implementation("com.google.guava:guava:30.1.1-jre")
     implementation("org.smali:dexlib2:2.5.2")
 

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/AdbExtensions.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/AdbExtensions.kt
@@ -82,6 +82,7 @@ internal fun Device.installApk(timeoutMillis: Long, apk: File): Either<Throwable
             Device.InstallOptions.builder()
                 .setTimeout(Duration.ofMillis(timeoutMillis))
                 .setAllowDowngrade(true)
+                .setGrantRuntimePermissions(true)
                 .setAllowReinstall(true)
                 .setAllowTestOnly(true)
                 .build()
@@ -97,6 +98,7 @@ internal fun Device.installApkSet(adb: AdbServer, timeoutMillis: Long, apkSet: F
                     "--timeout-millis=$timeoutMillis",
                     "--apks=${apkSet.path}",
                     "--allow-downgrade",
+                    "--grant-runtime-permissions",
                     "--allow-test-only",
                     "--device-id=$serialNumber",
                     onDemandDynamicModuleName?.let { "--modules=$it" }


### PR DESCRIPTION
The Google Bundletool version `1.15.0+` provides the functionality to also set the `-g` install flag, in addition to `-d`, `-r` and `-t`, which are already set as of now. Some tests require extra permissions, which is not a problem if all requested permissions are automatically granted at runtime (which is what `-g` does).

As the diff shows, I've only updated the `bundletool` dependency and added the flag in the `Device.installApk()` and `Device.installApkSet()` extension functions.