### PR TITLE
Add config param leaveApksInstalledAfterRun

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,9 @@ gordon {
 
     // Default is false - to ignore devices that failed during artifacts installation, may be useful with large number of devices and SinglePool strategy
     ignoreProblematicDevices.set(true)
+  
+    // Default is false - to leave apks installed after test run
+    leaveApksInstalledAfterRun.set(true)
 }
 ```
 

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonExtension.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonExtension.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2019 - 2025 Jack Henry & Associates, Inc.
+ * Copyright (C) 2025 Bayerische Motorenwerke AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.banno.gordon
 
 import org.gradle.api.model.ObjectFactory
@@ -17,6 +34,7 @@ abstract class GordonExtension @Inject constructor(
     val testFilter: Property<String> = objects.property()
     val testInstrumentationRunner: Property<String> = objects.property()
     val ignoreProblematicDevices: Property<Boolean> = objects.property()
+    val leaveApksInstalledAfterRun: Property<Boolean> = objects.property()
 
     init {
         poolingStrategy.convention(PoolingStrategy.PoolPerDevice)
@@ -27,5 +45,6 @@ abstract class GordonExtension @Inject constructor(
         testFilter.convention("")
         testInstrumentationRunner.convention("")
         ignoreProblematicDevices.convention(false)
+        leaveApksInstalledAfterRun.convention(false)
     }
 }

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonPlugin.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonPlugin.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2019 - 2025 Jack Henry & Associates, Inc.
+ * Copyright (C) 2025 Bayerische Motorenwerke AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.banno.gordon
 
 import com.android.build.api.artifact.SingleArtifact
@@ -96,6 +113,7 @@ class GordonPlugin : Plugin<Project> {
             task.extensionTestFilter.set(gordonExtension.testFilter)
             task.extensionTestInstrumentationRunner.set(gordonExtension.testInstrumentationRunner)
             task.ignoreProblematicDevices.set(gordonExtension.ignoreProblematicDevices)
+            task.leaveApksInstalledAfterRun.set(gordonExtension.leaveApksInstalledAfterRun)
         }
 
         val testedExtension = project.extensions.getByType<TestedExtension>()

--- a/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonTestTask.kt
+++ b/gordon-plugin/src/main/kotlin/com/banno/gordon/GordonTestTask.kt
@@ -1,3 +1,20 @@
+/*
+ * Copyright (C) 2019 - 2025 Jack Henry & Associates, Inc.
+ * Copyright (C) 2025 Bayerische Motorenwerke AG
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package com.banno.gordon
 
 import arrow.core.Either
@@ -71,6 +88,9 @@ internal abstract class GordonTestTask @Inject constructor(
 
     @get:Internal
     internal val ignoreProblematicDevices: Property<Boolean> = objects.property()
+
+    @get:Internal
+    internal val leaveApksInstalledAfterRun: Property<Boolean> = objects.property()
 
     @get:Internal
     internal val retryQuota: Property<Int> = objects.property()
@@ -202,12 +222,14 @@ internal abstract class GordonTestTask @Inject constructor(
 
             val htmlReportPath = testResults.htmlReport().write(reportDirectory.get().asFile).bind()
 
-            pools.flatMap { it.devices }.safeUninstall(
-                dispatcher = Dispatchers.Default,
-                timeoutMillis = installTimeoutMillis.get(),
-                applicationPackage = applicationPackage,
-                instrumentationPackage = instrumentationPackage.get()
-            )
+            if (!leaveApksInstalledAfterRun.get()) {
+                pools.flatMap { it.devices }.safeUninstall(
+                    dispatcher = Dispatchers.Default,
+                    timeoutMillis = installTimeoutMillis.get(),
+                    applicationPackage = applicationPackage,
+                    instrumentationPackage = instrumentationPackage.get()
+                )
+            }
 
             val testRunFailed =
                 testResults.getTestCasesByResult { it is TestResult.Failed || it is TestResult.NotRun }.isNotEmpty()


### PR DESCRIPTION
### :pushpin: References

* Related to https://github.com/Banno/Gordon/discussions/131

### :goal_net: What is the goal?

Inside GordonTest Task, after all tests are done, task will uninstall the application package and instrumentation package. This would also remove the data stored in the app storage during the tests.

Add configuration parameter leaveApksInstalledAfterRun to keep application data after Gordon tests. Inspired by Gradle Plugin 8.2's property:
android.injected.androidTest.leaveApksInstalledAfterRun = true.

### :computer: How is it implemented?

Pretty simple according to the other config parameters like `ignoreProblematicDevices`
