### PR TITLE
Support JVM 17 again

### DIFF
--- a/gordon-plugin/build.gradle.kts
+++ b/gordon-plugin/build.gradle.kts
@@ -29,14 +29,14 @@ dependencies {
 
 kotlin {
     compilerOptions {
-        jvmTarget = JvmTarget.JVM_21
+        jvmTarget = JvmTarget.JVM_17
         freeCompilerArgs.add("-Xconsistent-data-class-copy-visibility")
     }
 }
 
 tasks.withType<JavaCompile>().configureEach {
     sourceCompatibility = "21"
-    targetCompatibility = "21"
+    targetCompatibility = "17"
 }
 
 tasks.withType<Test>().configureEach {


### PR DESCRIPTION
### :goal_net: What is the goal?

Target compatibility 21 forces gordon users to update to JVM 21. This might not always easily possible, e.g. if the CI does not yet support it.

### :computer: How is it implemented?

Support was removed in `1.11.0`, where target compatibility was changed to `21`.
